### PR TITLE
CASMMON-485 upgrade logstash-exporter docker image to 1.9.0

### DIFF
--- a/kubernetes/logstash-exporter/Chart.yaml
+++ b/kubernetes/logstash-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: logstash-exporter
 description: Prometheus exporter for Logstash written in Go
 type: application
-version: "1.0.2"
-appVersion: "1.0.2"
+version: "1.9.0"
+appVersion: "1.9.0"

--- a/kubernetes/logstash-exporter/values.yaml
+++ b/kubernetes/logstash-exporter/values.yaml
@@ -10,10 +10,10 @@ logstash:
 image:
   ## @param image.repository Image repository
   ##
-  repository: "arti.hpc.amslabs.hpecorp.net/csm-docker-remote/unstable/docker.io/kuskoman/logstash-exporter"
+  repository: "artifactory.algol60.net/csm-docker/stable/docker.io/kuskoman/logstash-exporter"
   ## @param image.tag Image tag, if not set the appVersion is used
   ##
-  tag: "1.5.6"
+  tag: "1.9.0"
   ## @param image.pullPolicy Image pull policy
   ## Options: Always, Never, IfNotPresent
   ##


### PR DESCRIPTION
## Summary and Scope

Upgrades logstash-exporter to 1.9.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Related to https://jira-pro.it.hpe.com:8443/browse/CASMMON-485

